### PR TITLE
Bump detekt-formatting from 1.16.0 to 1.17.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ repositories {
   jcenter()
 }
 dependencies {
-  detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.16.0")
+  detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.17.0")
 }
 
 // Configure gradle-intellij-plugin plugin.


### PR DESCRIPTION
Bumps io.gitlab.arturbosch.detekt from 1.16.0 to 1.17.0.

Signed-off-by: dependabot[bot] <support@github.com>

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**
<!--- Describe the change below, including rationale and design decisions -->
* Update dependencies
   - io.gitlab.arturbosch.detekt:detekt-formatting

<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->